### PR TITLE
Refactor text editor logic into hooks

### DIFF
--- a/src/features/text-editor/CollaborativeEditor.tsx
+++ b/src/features/text-editor/CollaborativeEditor.tsx
@@ -1,8 +1,7 @@
-import { useState, useEffect, useRef } from 'react';
+import { useRef } from 'react';
 import { TextDisplay } from './TextDisplay';
 import { SuggestionPanel } from './suggestion-panel/SuggestionPanel';
-import { useTextData } from './useTextData';
-import { useYjs } from '../../providers/YjsProvider';
+import { useEditorActions } from './hooks/useEditorActions';
 import { motion, type Variants } from 'framer-motion';
 import AnimatedText from '../../components/AnimatedText';
 const containerVariants: Variants = {
@@ -41,14 +40,16 @@ const pulseVariants: Variants = {
 };
 
 export const CollaborativeEditor = () => {
-    const { isSynced, awareness } = useYjs();
-    const { words, addSuggestion, voteOnSuggestion } = useTextData();
-    const [selectedWordIndex, setSelectedWordIndex] = useState<number | null>(null);
+    const {
+        isSynced,
+        words,
+        selectedWord,
+        selectedWordIndex,
+        handleWordClick,
+        handleAddSuggestion,
+        handleVote,
+    } = useEditorActions();
     const suggestionPanelRef = useRef<HTMLDivElement>(null);
-
-    useEffect(() => {
-        awareness.setLocalStateField('selectedWordIndex', selectedWordIndex);
-    }, [selectedWordIndex, awareness]);
 
     if (!words.length) {
         return (
@@ -76,19 +77,6 @@ export const CollaborativeEditor = () => {
             </div>
         );
     }
-
-    const selectedWord = selectedWordIndex !== null ? words[selectedWordIndex] : undefined;
-
-    const handleAddSuggestion = (text: string) => {
-        if (selectedWordIndex !== null) addSuggestion(selectedWordIndex, text);
-    };
-
-    const handleVote = (suggestionId: string) => {
-        if (selectedWordIndex !== null) voteOnSuggestion(selectedWordIndex, suggestionId);
-    }; const handleWordClick = (index: number) => {
-        const newIndex = selectedWordIndex === index ? null : index;
-        setSelectedWordIndex(newIndex);
-    };
 
     return (
         <div className="min-h-screen bg-gradient-to-br from-primary via-primary to-secondary">

--- a/src/features/text-editor/hooks/useEditorActions.ts
+++ b/src/features/text-editor/hooks/useEditorActions.ts
@@ -1,0 +1,61 @@
+import { useState, useEffect } from 'react';
+import { useYjs } from '../../providers/YjsProvider';
+import { useTextData } from '../useTextData';
+import { Word } from '../types';
+
+export interface UseEditorActionsConfig {
+    onSelectionChange?: (index: number | null) => void;
+}
+
+export interface UseEditorActions {
+    isSynced: boolean;
+    words: Word[];
+    selectedWordIndex: number | null;
+    selectedWord: Word | undefined;
+    handleWordClick: (index: number) => void;
+    handleAddSuggestion: (text: string) => void;
+    handleVote: (suggestionId: string) => void;
+}
+
+export const useEditorActions = (
+    config: UseEditorActionsConfig = {}
+): UseEditorActions => {
+    const { onSelectionChange } = config;
+    const { isSynced, awareness } = useYjs();
+    const { words, addSuggestion, voteOnSuggestion } = useTextData();
+    const [selectedWordIndex, setSelectedWordIndex] = useState<number | null>(null);
+
+    useEffect(() => {
+        awareness.setLocalStateField('selectedWordIndex', selectedWordIndex);
+        onSelectionChange?.(selectedWordIndex);
+    }, [selectedWordIndex, awareness, onSelectionChange]);
+
+    const selectedWord =
+        selectedWordIndex !== null ? words[selectedWordIndex] : undefined;
+
+    const handleWordClick = (index: number) => {
+        setSelectedWordIndex(prev => (prev === index ? null : index));
+    };
+
+    const handleAddSuggestion = (text: string) => {
+        if (selectedWordIndex !== null) {
+            addSuggestion(selectedWordIndex, text);
+        }
+    };
+
+    const handleVote = (suggestionId: string) => {
+        if (selectedWordIndex !== null) {
+            voteOnSuggestion(selectedWordIndex, suggestionId);
+        }
+    };
+
+    return {
+        isSynced,
+        words,
+        selectedWordIndex,
+        selectedWord,
+        handleWordClick,
+        handleAddSuggestion,
+        handleVote,
+    };
+};

--- a/src/features/text-editor/suggestion-panel/AddSuggestionForm.tsx
+++ b/src/features/text-editor/suggestion-panel/AddSuggestionForm.tsx
@@ -1,23 +1,23 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { motion } from 'framer-motion';
 import { PlusCircle } from 'lucide-react';
+import { useAddSuggestionForm } from './hooks/useAddSuggestionForm';
 
 interface Props {
     onAddSuggestion: (text: string) => void;
 }
 
 export const AddSuggestionForm = ({ onAddSuggestion }: Props) => {
-    const [newSuggestion, setNewSuggestion] = useState('');
-    const [isSubmitting, setIsSubmitting] = useState(false);
+    const {
+        newSuggestion,
+        setNewSuggestion,
+        isSubmitting,
+        submit,
+    } = useAddSuggestionForm(onAddSuggestion);
 
-    const handleSubmit = async (e: React.FormEvent) => {
+    const handleSubmit = (e: React.FormEvent) => {
         e.preventDefault();
-        if (newSuggestion.trim() && !isSubmitting) {
-            setIsSubmitting(true);
-            onAddSuggestion(newSuggestion.trim());
-            setNewSuggestion('');
-            setTimeout(() => setIsSubmitting(false), 300);
-        }
+        submit();
     };
 
     return (

--- a/src/features/text-editor/suggestion-panel/hooks/useAddSuggestionForm.ts
+++ b/src/features/text-editor/suggestion-panel/hooks/useAddSuggestionForm.ts
@@ -1,0 +1,24 @@
+import { useState } from 'react';
+
+export const useAddSuggestionForm = (
+    onAddSuggestion: (text: string) => void
+) => {
+    const [newSuggestion, setNewSuggestion] = useState('');
+    const [isSubmitting, setIsSubmitting] = useState(false);
+
+    const submit = () => {
+        if (newSuggestion.trim() && !isSubmitting) {
+            setIsSubmitting(true);
+            onAddSuggestion(newSuggestion.trim());
+            setNewSuggestion('');
+            setTimeout(() => setIsSubmitting(false), 300);
+        }
+    };
+
+    return {
+        newSuggestion,
+        setNewSuggestion,
+        isSubmitting,
+        submit,
+    };
+};

--- a/src/features/text-editor/useTextData.ts
+++ b/src/features/text-editor/useTextData.ts
@@ -6,7 +6,7 @@ import { getOrCreateUserId } from '../../lib/userStorageUtil';
 
 const MOCK_TEXT = "React is a JavaScript library for building user interfaces.";
 
-const ySuggestionToSuggestion = (yMap: Y.Map<any>): Suggestion => ({
+const ySuggestionToSuggestion = (yMap: Y.Map<unknown>): Suggestion => ({
     id: yMap.get('id'),
     text: yMap.get('text'),
     votes: yMap.get('votes'),
@@ -14,7 +14,7 @@ const ySuggestionToSuggestion = (yMap: Y.Map<any>): Suggestion => ({
     votedBy: yMap.get('votedBy')?.toArray() ?? [],
 });
 
-const yWordToWord = (yMap: Y.Map<any>): Word => ({
+const yWordToWord = (yMap: Y.Map<unknown>): Word => ({
     id: yMap.get('id'),
     text: yMap.get('text'),
     suggestions: yMap.get('suggestions').toArray().map(ySuggestionToSuggestion),
@@ -24,7 +24,7 @@ export const useTextData = () => {
     const { doc, isSynced } = useYjs();
     const [words, setWords] = useState<Word[]>([]);
 
-    const yWords = useMemo(() => doc.getArray<Y.Map<any>>('text-words'), [doc]);
+    const yWords = useMemo(() => doc.getArray<Y.Map<unknown>>('text-words'), [doc]);
     const yMeta = useMemo(() => doc.getMap('text-meta'), [doc]);
 
     useEffect(() => {
@@ -70,7 +70,7 @@ export const useTextData = () => {
         if (!wordMap) return;
 
         const authorId = getOrCreateUserId();
-        const suggestionsArray = wordMap.get('suggestions') as Y.Array<Y.Map<any>>;
+        const suggestionsArray = wordMap.get('suggestions') as Y.Array<Y.Map<unknown>>;
 
         // Prevent duplicate suggestions
         const existingSuggestion = suggestionsArray.toArray().some(s => s.get('text').toLowerCase() === suggestionText.toLowerCase());
@@ -94,7 +94,7 @@ export const useTextData = () => {
         const wordMap = yWords.get(wordIndex);
         if (!wordMap) return;
 
-        const suggestionsArray = wordMap.get('suggestions') as Y.Array<Y.Map<any>>;
+        const suggestionsArray = wordMap.get('suggestions') as Y.Array<Y.Map<unknown>>;
         const suggestionMap = suggestionsArray.toArray().find(s => s.get('id') === suggestionId);
         if (!suggestionMap) return;
 


### PR DESCRIPTION
## Summary
- create `useEditorActions` hook encapsulating state and Yjs awareness
- create `useAddSuggestionForm` for suggestion form state
- update `CollaborativeEditor` and `AddSuggestionForm` to use hooks
- fix lint warnings by replacing `Y.Map<any>` generics

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687ce95bbff483279e68f69b7f58bc1e